### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for Elasticsearch operations, providing a comprehensive set of tools for interacting with Elasticsearch clusters through the standardized Model Context Protocol. This server enables LLM-powered applications to search, update, and manage Elasticsearch data.
 
+<a href="https://glama.ai/mcp/servers/@Octodet/elasticsearch-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Octodet/elasticsearch-mcp/badge" alt="octodet-elasticsearch-mcp MCP server" />
+</a>
+
 ## Features
 
 - **Complete Elasticsearch Operations**: Full CRUD operations for documents and indices


### PR DESCRIPTION
This PR adds a badge for the [octodet-elasticsearch-mcp](https://glama.ai/mcp/servers/@Octodet/elasticsearch-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Octodet/elasticsearch-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Octodet/elasticsearch-mcp/badge" alt="octodet-elasticsearch-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.